### PR TITLE
修改考试部分

### DIFF
--- a/src/views/exam/components/ExamSummaryDialog.vue
+++ b/src/views/exam/components/ExamSummaryDialog.vue
@@ -1,0 +1,266 @@
+<template>
+  <el-dialog
+    top="2vh"
+    title="考前汇总"
+    :visible.sync="dialogVisible"
+    width="80%"
+    :before-close="handleClose"
+  >
+    <el-container style="height: 70vh; border: 1px solid #eee">
+      <el-container>
+        <el-main class="right">
+          <el-col>
+            <el-card class="qu_list">
+              <div>
+                <!-- 客观题部分 -->
+                <template v-for="(item, index) in recordData">
+                  <div
+                    v-if="item.quType === 1 || item.quType === 2 || item.quType === 3"
+                    :key="'obj-' + index"
+                    :class="'index' + index"
+                  >
+                    <el-row :gutter="24">
+                      <el-col :span="20" style="text-align: left">
+                        <!-- 题干区域 -->
+                        <div>
+                          <div class="qu_content">
+                            <span class="qu_num">{{ index + 1 }}. </span>{{ item.title }}
+                          </div>
+                          <div v-if="item.image != null && item.image != ''">
+                            <el-image :src="item.image" style="max-width: 200px;" />
+                          </div>
+                        </div>
+
+                        <!-- 选项区域 -->
+                        <el-radio-group class="qu_choose_group">
+                          <el-radio
+                            v-for="(option, optionIndex) in item.option"
+                            :key="'option-' + optionIndex"
+                            :label="option.content"
+                            border
+                            class="qu_choose"
+                            :class="{
+                              'current': item.myOption != null && isCheck(item.myOption, option.sort),
+                              'imgC': option.image != null && option.image != '',
+                            }"
+                          >
+                            {{ numberToLetter(optionIndex) }}、{{ option.content }}
+                            <div v-if="option.image != null && option.image != ''">
+                              <el-image :src="option.image" style="max-width: 200px" class="qu_choose_tag_img" />
+                            </div>
+                          </el-radio>
+                        </el-radio-group>
+
+                        <!-- 我的答案区域 -->
+                        <div class="qu_analysis">
+                          <el-card>
+                            <div>
+                              <span>我的答案：</span>
+                              <span
+                                :style="{
+                                  color: getAnswerColor(item.isRight)
+                                }"
+                              >
+                                {{ numberToLetter(item.myOption) }}
+                              </span>
+                            </div>
+                          </el-card>
+                        </div>
+                      </el-col>
+                    </el-row>
+                    <el-divider />
+                  </div>
+                </template>
+
+                <!-- 主观题部分 -->
+                <template v-for="(item, index) in recordData">
+                  <div
+                    v-if="item.quType === 4"
+                    :key="'subj-' + index"
+                    :class="'index' + index"
+                  >
+                    <el-row :gutter="24">
+                      <el-col :span="20" style="text-align: left">
+                        <!-- 题干部分 -->
+                        <div>
+                          <div class="qu_content">
+                            <span class="qu_num">{{ index + 1 }}. </span>{{ item.title }}
+                          </div>
+                        </div>
+
+                        <!-- 简答题内容区域 -->
+                        <el-radio-group class="qu_choose_group">
+                          <el-input
+                            v-model="item.myOption"
+                            style="margin-top: 10px"
+                            type="textarea"
+                            :autosize="{ minRows: 2, maxRows: 4 }"
+                            placeholder="请输入内容"
+                            readonly
+                          />
+                        </el-radio-group>
+                      </el-col>
+                    </el-row>
+                    <el-divider />
+                  </div>
+                </template>
+              </div>
+              <el-divider />
+            </el-card>
+          </el-col>
+        </el-main>
+      </el-container>
+    </el-container>
+    <span slot="footer" class="dialog-footer">
+      <el-button @click="onCancel">取 消</el-button>
+      <el-button type="primary" @click="onConfirm">确 定</el-button>
+    </span>
+  </el-dialog>
+</template>
+
+<script>
+export default {
+  name: 'ExamSummaryDialog',
+  props: {
+    visible: {
+      type: Boolean,
+      default: false
+    },
+    recordData: {
+      type: Array,
+      default: () => []
+    }
+  },
+  computed: {
+    dialogVisible: {
+      get() {
+        return this.visible;
+      },
+      set(val) {
+        this.$emit('update:visible', val);
+      }
+    }
+  },
+  methods: {
+    // 检查选项是否被选中
+    isCheck(myOption, sort) {
+      if (!myOption) return false;
+      const arr = myOption.split(",").map(Number);
+      return arr.includes(sort);
+    },
+
+    // 处理对话框关闭
+    handleClose(done) {
+      this.$emit('close');
+      done();
+    },
+
+    // 取消按钮
+    onCancel() {
+      this.dialogVisible = false;
+    },
+
+    // 确认按钮
+    onConfirm() {
+      this.$emit('confirm');
+      this.dialogVisible = false;
+    },
+
+    // 获取答案颜色
+    getAnswerColor(isRight) {
+      if (isRight === 1) return 'green';
+      if (isRight === 0) return 'red';
+      return 'gray';
+    },
+
+    // 将数字转换为字母
+    numberToLetter(input) {
+      if (input === null || input === undefined) return "";
+
+      const numberToCharMap = {
+        0: "A", 1: "B", 2: "C", 3: "D", 4: "E", 5: "F"
+      };
+
+      // 处理单个数字
+      if (typeof input === 'number' || /^\d+$/.test(input)) {
+        return numberToCharMap[parseInt(input, 10)] || "";
+      }
+
+      // 处理逗号分隔的数字
+      if (/^\d+(,\d+)*$/.test(input)) {
+        return input.split(",")
+          .map(num => numberToCharMap[parseInt(num.trim(), 10)] || "")
+          .join(",");
+      }
+
+      return "";
+    }
+  }
+}
+</script>
+
+<style scoped>
+.right {
+  width: 100%;
+  height: 100%;
+}
+
+.el-divider--horizontal {
+  display: block;
+  height: 1px;
+  width: 95%;
+  margin: 24px 0;
+}
+
+/* 试题内容样式 */
+.qu_list {
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+  page-break-after: always;
+}
+
+.qu_content {
+  padding-left: 10px;
+}
+
+/* 题号样式 */
+.qu_num {
+  font-weight: bold;
+  margin-right: 5px;
+}
+
+/* 选项组 */
+.qu_choose_group {
+  width: 100%;
+}
+
+/* 单个选项 */
+.qu_choose {
+  display: block;
+  margin: 10px;
+}
+
+.current {
+  background: #f5f5f5;
+}
+
+.imgC {
+  height: 150px;
+}
+
+.qu_choose_tag_img {
+  height: auto;
+  display: block;
+  margin: 10px;
+}
+
+/* 试题解析 */
+.qu_analysis {
+  padding: 10px;
+}
+
+.qu_analysis_content {
+  padding-top: 10px;
+}
+</style>

--- a/src/views/exam/components/QuestionCardSection.vue
+++ b/src/views/exam/components/QuestionCardSection.vue
@@ -1,0 +1,73 @@
+<template>
+  <div v-if="questions && questions.length > 0">
+    <p class="card-title">{{ title }}</p>
+    <el-row :gutter="24" class="card-line">
+      <el-tag
+        v-for="(item, index) in questions"
+        :key="index"
+        :type="getCardItemClass(item)"
+        style="width: calc(100% / 8); text-align: center; margin: 2px;"
+        @click="selectQuestion(item)"
+      >
+        {{ item.sort + 1 }}
+      </el-tag>
+    </el-row>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'QuestionCardSection',
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    questions: {
+      type: Array,
+      required: true
+    },
+    currentItem: {
+      type: Object,
+      required: true
+    }
+  },
+  methods: {
+    selectQuestion(item) {
+      this.$emit('select-question', item)
+    },
+    getCardItemClass(item) {
+      // 当前题目
+      if (item.questionId === this.currentItem.questionId) {
+        return 'warning'
+      }
+      // 已答题
+      if (item.checkout === 1) {
+        return 'success'
+      }
+      // 未答题
+      return 'info'
+    }
+  }
+}
+</script>
+
+<style scoped>
+.card-title {
+  background: #eee;
+  line-height: 35px;
+  text-align: center;
+  font-size: 14px;
+}
+
+.card-line {
+  padding-left: 10px;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.card-line span {
+  cursor: pointer;
+  margin: 2px;
+}
+</style>

--- a/src/views/exam/examInformation.vue
+++ b/src/views/exam/examInformation.vue
@@ -106,6 +106,12 @@ export default {
     startExam() {
       examStart(this.receivedRow).then((res) => {
         if (res.code) {
+          // 删除当前标签页
+          this.$store.commit('menu/REMOVE_TAG', {
+            title: this.$route.meta.title,  // 从路由元数据中获取标题
+            path: this.$route.path,
+            name: this.$route.name          // 添加路由名称
+          });
           localStorage.setItem('examId', this.receivedRow)
           this.$router.push({ name: 'start', query: { zhi: this.receivedRow }})
         } else {

--- a/src/views/login/index.vue
+++ b/src/views/login/index.vue
@@ -152,6 +152,12 @@ export default {
   created() {
     // this.getEmail()
   },
+  mounted() {
+    // 页面加载完成后自动聚焦到用户名输入框
+    this.$nextTick(() => {
+      this.$refs.username.focus();
+    });
+  },
   computed: {
     redirect() {
       return this.$route.query.redirect || '/index'; // 如果没有 redirect 参数，默认跳转到首页


### PR DESCRIPTION
答题卡、考前汇总拆分成组件
答题卡样式修改
点击上一题或下一题时，答案未更改或空答案不再强制提交
最后一题增加提交答案按钮

考前汇总右上角关闭弹窗不再二次确认
考前汇总题目顺序与答题卡一致并增加序号
考前汇总--我的答案按自然顺序排列，不再按点击顺序，比如做题的时候选择了BDA，我的答案显示ABD
